### PR TITLE
add support for callbacks to support assigning to array subkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ the value can be callback, to allow assigning value to sub-keys.
 Here's example using [saxulum/saxulum-doctrine-mongodb-odm-provider]:
 
 ```php
-$this->register(new DockerSecretsProvider([
+$this->register(new DockerSecretsProvider(array(
     'mongodb' => function ($secretReader, $app) {
         // make copy for later assignment,
         $options = $app['mongodb.options'];
@@ -78,7 +78,7 @@ $this->register(new DockerSecretsProvider([
             return $options;
         };
     },
-]));
+)));
 ```
 
 To avoid `Indirect modification of overloaded element`,

--- a/README.md
+++ b/README.md
@@ -59,3 +59,27 @@ $app->register(new DockerSecretsProvider(array(
 ```
 
 This would make `$app['my.secret']` read as `"This is a secret"`
+
+In case of nested structure, the value can be callback,
+this allows to assign value to array sub-keys.
+
+However, in case the parent array is also lazy inited,
+you need to make copy and assign the value again.
+
+Here's example using [saxulum/saxulum-doctrine-mongodb-odm-provider]:
+
+```php
+$this->register(new DockerSecretsProvider([
+    'mongodb' => function ($secretReader, $app) {
+        $options = $app['mongodb.options'];
+
+        $app['mongodb.options'] = function () use ($secretReader, $options, $app) {
+            $options['options']['password'] = $secretReader();
+
+            return $options;
+        };
+    },
+]));
+```
+
+[saxulum/saxulum-doctrine-mongodb-odm-provider]: https://packagist.org/packages/saxulum/saxulum-doctrine-mongodb-odm-provider

--- a/src/DockerSecretsProvider.php
+++ b/src/DockerSecretsProvider.php
@@ -49,7 +49,7 @@ class DockerSecretsProvider implements ServiceProviderInterface {
 			};
 
 			// let closure figure out what to do with the value
-			if (is_callable($value)) {
+			if (method_exists($value, '__invoke')) {
 				$value($secretReader, $app);
 
 				continue;


### PR DESCRIPTION
Allows mapping secrets to nested structure (`$app['option']['key']`).

The the closure is needed to read the secret to the memory on demand, not on initialization phase.

```php
$app['example'] = array(
    'options' => array(),
);

$app->register(new DockerSecretsProvider(array(
    'example' => function ($secretReader, $app) {
        $options = $app['example'];

        $app['example'] = function() use ($secretReader, $options) {
            $options['options']['key'] = $secretReader();

            return $options;
        };
    },
)));

print_r($app['example']['options']['key']);
```